### PR TITLE
Moving code from KB to Miscellany

### DIFF
--- a/hosts_with_aws_without_agent.py
+++ b/hosts_with_aws_without_agent.py
@@ -1,0 +1,31 @@
+#-*- coding:utf8 -*-
+
+# See instructions here: https://help.datadoghq.com/hc/en-us/articles/115000075046-List-of-ec2-instances-without-the-datadog-agent-installed
+
+# 3p
+import requests
+
+# stdlib
+import json
+import pprint
+
+api_key = 'YOUR_API_KEY_GOES_HERE'
+app_key = 'YOUR_APPLICATION_KEY_GOES_HERE'
+
+url = "https://app.datadoghq.com/reports/v2/overview?\
+window=3h&with_apps=true&with_sources=true&with_aliases=true\
+&with_meta=true&with_tags=true&api_key=%s&application_key=%s"
+
+infra = json.loads(requests.get(url %(api_key,app_key)).text)
+
+for host in infra['rows']:
+    if (('aws' in host['apps']) and ('agent' not in host['apps'])):
+
+        ip = ''
+        try:
+            gohai = json.loads(host['meta']['gohai'])
+            ip = gohai['network']['ipaddress']
+        except:
+            pass
+
+        print "%s  %s" %(host['name'],ip)


### PR DESCRIPTION
From https://help.datadoghq.com/hc/en-us/articles/115000075046-List-of-ec2-instances-without-the-datadog-agent-installed