### PR TITLE
Powershell script call endpoint submit to dogstatsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These scripts and tools live in this repo, some scripts/tools have their own REA
 | [query hosts and create tags](./query_hosts_create_tags.py)               | Python      | queries hosts api using pagination and creates new tags                                                                                                                                                                                                                              |
 | [get all groups in a monitor](./monitors/get_groups_in_monitor.py)               | Python      | queries for all groups in a monitor and outputs a list of them                                                                                                                                                                                                                              |
 | [create a csv file with a list of log in handles](./create_email_list.py)     | Python       | creates a CSV file in the same directory as the script containing a list of all user log in handles |
+| [Powershell script to call JSON REST endpoint, pass those key-value pairs to DogstatsD](./requester.ps1)     | Powershell       | A Powershell script which will call a given HTTP GET endpoint, and then submit the key-value pairs found in the resulting JSON body to DogsStatsD. Resource endpoint must be a non-nested JSON body ({"a":"1","b":"2"} -> custom metrics: a\|1, b\|2 |
 ## Additional tools
 These are some additional tools and scripts written by Datadog.
 

--- a/requester.ps1
+++ b/requester.ps1
@@ -1,0 +1,28 @@
+<# 
+This script will establish a UDP client, connect it to 127.0.0.1:8125, 
+invoke a request to our supplied endpoint, parse the json returned from that,
+and send the key-value pairs from that json to dogstatsd which will then send
+them through to datadog as custom metrics.
+#>
+
+$dogstatsdAddress = '127.0.0.1'
+$dogstatsdPort = '8125'
+
+$restEndpoint = 'http://127.0.0.1:5000/'
+
+# udp client
+$udpClient = New-Object System.Net.Sockets.UdpClient 
+$udpClient.Connect($dogstatsdAddress, $dogstatsdPort)
+# invoke request to get json data from endpoint, and parse response
+$ipinfo = Invoke-WebRequest $restEndpoint -UseBasicParsing | ConvertFrom-Json
+foreach ($info in $ipinfo.PSObject.Properties) {
+    # get name and value of current json element
+    $metricName = $info.Name
+    $metricValue = $info.Value
+    Write-Host "Metric Name: $metricName | Metric Value: $metricValue "
+    # encode data s.t. dogstatsd accepts it
+    $encodedData=[System.Text.Encoding]::ASCII.GetBytes("${metricName}:${metricValue}|g") # curly brackets these otherwise it'll interpret it as a property value
+    Write-Host "data to be sent to DogstatsD: $encodedData"
+    # send it through to our udp client (pointed to dogstatsd)
+    $bytesSent=$udpClient.Send($encodedData,$encodedData.Length)
+    Write-Host "bytesSent: $bytesSent"


### PR DESCRIPTION
A customer asked me to help him create a Powershell script which does the following:
1. makes callout to HTTP endpoint using a GET which returns a non-nested JSON of simple key-value pairs (no values that are objects, arrays)
2. send resulting custom metrics through to dogstatsd. 

a custom metric will be creating for each pairing returned

for instance if our endpoint returns `{"k1": "abc", "k2": "def"}`, then dogstatsd will receive 2 udp datagrams which will shoot it through to DD to create 2 custom metrics. one with key k1 and value abc, and one with key k2 and value def. 

i think the odds of another customer asking the exact same question are quite low, and it was a fairly niche question but i thought it would be better to have the script down in a repo rather than a private gist.