### PR TITLE
Dogmover – tool to help you migrate one organization to another.

### DIFF
--- a/Dogmover/README.MD
+++ b/Dogmover/README.MD
@@ -3,22 +3,22 @@ This tool was originally built to help migrate customers screenboards, timeboard
 
 ## Install
 1. Clone this repository.
-2. Install all python dependencies: ``pip install -r requirements.txt --upgrade``
-2. Add your _api_key_, _app_key_ to ``config.json`` for both the source (the organization where you will pull the data from) and the destination (to where you will be pushing the data to). See config.json.example. 
+2. Install all python dependencies: `pip install -r requirements.txt --upgrade`
+2. Add your _api_key_, _app_key_ to `config.json` for both the source (the organization where you will pull the data from) and the destination (to where you will be pushing the data to). See `config.json.example`. 
 
 ## Usage
 To pull (export) a organizations screenboards, do:
-``./dogmover.py pull screenboards --dry-run``
+`./dogmover.py pull screenboards --dry-run`
 To push (import) a organizations screenboards, do:
-``./dogmover.py push screenboards --dry-run``
+`./dogmover.py push screenboards --dry-run`
 
 The arguments supported are:
-``./dogmover.py pull|push screenboards|timeboards|monitors [--dry-run] ``
+`./dogmover.py pull|push screenboards|timeboards|monitors [--dry-run] `
 
-If you feel safe with the output Dogmover is giving you, run without ``--dry-run`` to make an actual pull/push.
+If you feel safe with the output Dogmover is giving you, run without `--dry-run` to make an actual pull/push.
 
 ### Note
-1. When not running in --dry-mode, all pulls will create a JSON file locally on your file system, which can be useful if you are looking to backup data with pull (for say, version controlling). The files are stored in:
+1. When not running in `--dry-run` mode, all pulls will create a JSON file locally on your file system, which can be useful if you are looking to backup data with pull (for say, version controlling). The files are stored in:
 ``` 
 ./screnboards/*.json
 ./timeboards/*.json
@@ -28,4 +28,4 @@ If you feel safe with the output Dogmover is giving you, run without ``--dry-run
 2. If you are pushing monitors, all your monitors will be automatically muted to suppress monitors from triggering false/positive alerts as we help migrate customers from one instance to another. This is done as a scheduled downtime, remove it in the GUI if this is not what you want.
 
 ### Known issues
-1. EU instance is not supported in Datadogpy <0.3.0, please make sure to run ``pip install -r requirements.txt --upgrade`` or Dogmover may not work as expected for you.
+1. EU instance is not supported in Datadogpy <0.3.0, please make sure to run `pip install -r requirements.txt --upgrade` or Dogmover may not work as expected for you.

--- a/Dogmover/README.MD
+++ b/Dogmover/README.MD
@@ -1,0 +1,31 @@
+# DogMover
+This tool was originally built to help migrate customers screenboards, timeboards and monitors from our US instance to our EU instance. The tool also supports moving the data within the same instances (eg., EU to EU, or US to US and even EU to US.)
+
+## Install
+1. Clone this repository.
+2. Install all python dependencies: ``pip install -r requirements.txt --upgrade``
+2. Add your _api_key_, _app_key_ to ``config.json`` for both the source (the organization where you will pull the data from) and the destination (to where you will be pushing the data to). See config.json.example. 
+
+## Usage
+To pull (export) a organizations screenboards, do:
+``./dogmover.py pull screenboards --dry-run``
+To push (import) a organizations screenboards, do:
+``./dogmover.py push screenboards --dry-run``
+
+The arguments supported are:
+``./dogmover.py pull|push screenboards|timeboards|monitors [--dry-run] ``
+
+If you feel safe with the output Dogmover is giving you, run without ``--dry-run`` to make an actual pull/push.
+
+### Note
+1. When not running in --dry-mode, all pulls will create a JSON file locally on your file system, which can be useful if you are looking to backup data with pull (for say, version controlling). The files are stored in:
+``` 
+./screnboards/*.json
+./timeboards/*.json
+./monitors/*.json
+```
+
+2. If you are pushing monitors, all your monitors will be automatically muted to suppress monitors from triggering false/positive alerts as we help migrate customers from one instance to another. This is done as a scheduled downtime, remove it in the GUI if this is not what you want.
+
+### Known issues
+1. EU instance is not supported in Datadogpy <0.3.0, please make sure to run ``pip install -r requirements.txt --upgrade`` or Dogmover may not work as expected for you.

--- a/Dogmover/config.json.example
+++ b/Dogmover/config.json.example
@@ -1,0 +1,9 @@
+{
+    "source_api_key": "<api_key>",
+    "source_app_key": "<app_key>",
+    "source_api_host": "https://api.datadoghq.com/",
+
+    "dest_api_key": "<api_key>",
+    "dest_app_key": "<app_key>",
+    "dest_api_host": "https://api.datadoghq.eu/"
+}

--- a/Dogmover/dogmover.py
+++ b/Dogmover/dogmover.py
@@ -1,0 +1,217 @@
+"""Usage:
+  dogmover.py pull (<type>) [--dry-run]
+  dogmover.py push (<type>) [--dry-run]
+
+Example, try with --dry-run first:
+    dogmover.py pull timeboards --dry-run
+    dogmover.py push timeboards --dry-run
+    to make actual changes:
+    dogmover.py pull timeboards
+    and finally push to another organization:
+    dogmover.py push timeboards
+
+    Supported arguments:
+    dogmover.py pull|push screenboards|monitors|dashboards
+
+Options:
+  -h, --help
+  -d, --dry-run
+"""
+__author__ = "Misiu Pajor <misiu.pajor@datadoghq.com>"
+__version__ = "1.0.0"
+from docopt import docopt
+import json
+import os
+import glob
+from datadog import initialize, api
+
+def _init_options(action):
+    config_file = "config.json"
+    try:
+        with open(config_file) as f:
+            config = json.load(f)
+    except IOError:
+        exit("No configuration file named: {} could be found.".format(config_file))
+    
+    options = {}
+    if action == "pull":   
+        options = {
+            'api_key': config["source_api_key"],
+            'app_key': config["source_app_key"],
+            'api_host': config["source_api_host"]
+        }
+    elif action == "push":
+            options = {
+                'api_key': config["dest_api_key"],
+                'app_key': config["dest_app_key"],
+                'api_host': config["dest_api_host"]
+            }
+
+    initialize(**options)
+    return options
+
+def _ensure_directory(directory):
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+    return directory
+
+def _json_to_file(path, fileName, data):
+    filePathNameWExt = './' + path + '/' + fileName + '.json'
+    _ensure_directory(path)
+    with open(filePathNameWExt, 'w') as fp:
+        json.dump(data, fp, sort_keys = True, indent = 4)
+    return filePathNameWExt
+
+def _files_to_json(type):
+    files = glob.glob('{}/*.json'.format(type))
+    return files
+
+
+def pull_screenboards():
+    path = "none, running in dry mode."
+    count = 0
+    screenboards = api.Screenboard.get_all()
+
+    for board in screenboards["screenboards"]:
+        count = count + 1 
+        json_data = api.Screenboard.get(board["id"])
+        if not arguments["--dry-run"]:
+            path = _json_to_file('screenboards', str(board["id"]), json_data)
+        print("Pulling: {} with id: {}, writing to file: {}".format(board["title"].encode('utf8'), board["id"], path))
+    print("Retrieved '{}' screenboards.".format(count))
+
+def pull_timeboards():
+    path = "none, running in dry mode."
+    count = 0
+    timeboards = api.Timeboard.get_all()
+
+    for board in timeboards["dashes"]:
+        count = count + 1
+        json_data = api.Timeboard.get(board["id"])
+        if not arguments["--dry-run"]:
+            path = _json_to_file('timeboards', str(board["id"]), json_data) 
+        print("Pulling: '{}' with id: {}, writing to file: {}".format(board["title"].encode('utf8'), board["id"], path))
+    print("Retrieved '{}' timeboards.".format(count))
+
+
+def pull_monitors():
+    path = "none, running in dry mode."
+    good_keys = ['tags', 'deleted', 'query', 'message', 'matching_downtimes', 'multi', 'name', 'type', 'options', 'id']
+    new_monitors = []
+    count = 0
+
+    monitors = api.Monitor.get_all()
+    for monitor in monitors:
+        count = count + 1
+        new_monitor = {}
+        for k, v in monitor.items():
+            if k in good_keys:
+                new_monitor[k] = v
+        if not arguments["--dry-run"]:
+            path = _json_to_file('monitors', str(new_monitor["id"]), new_monitor)
+        print("Pulling: {} with id: {}, writing to file: {}".format(new_monitor["name"].encode('utf8'), new_monitor["id"], path))
+    print("Retrieved '{}' monitors.".format(count))
+    return new_monitors
+
+
+def push_screenboards():
+    path = "none, running in dry mode."
+    count = 0
+
+    screenboards = _files_to_json("screenboards")
+    if not screenboards:
+        exit("No screenboards have been pulled yet. Consider pulling screenboards first.")
+    for screenboard in screenboards:
+        with open(screenboard) as f:
+            data = json.load(f)
+            count = count + 1
+            if 'description' not in data:
+                data["description"] = ""
+            if 'width' not in data:
+                data["width"] = "1024"
+            # skip screenboards with no widgets in them
+            if 'widgets' not in data:
+                print("...Skipping {} as this screenboard has no widgets in it.".format(data["board_title"].encode("utf8")))
+                continue
+            print("Pushing {}".format(data["board_title"].encode('utf8')))    
+            if not arguments["--dry-run"]:
+                api.Screenboard.create(board_title=data["board_title"],
+                                    description=data["description"],
+                                    widgets=data["widgets"],
+                                    template_variables=data["template_variables"],
+                                    width=data["width"])
+            print("Pushed {} screenboards".format(count))
+
+def push_timeboards():
+    path = "none, running in dry mode."
+    count = 0
+
+    timeboards = _files_to_json("timeboards")
+    if not timeboards:
+        exit("No timeboards have been pulled yet. Consider timeboards first.")
+    for timeboard in timeboards:
+        with open(timeboard) as f:
+            data = json.load(f)
+            count = count + 1
+            if not 'template_variables' in data["dash"]:
+                data["dash"]["template_variables"] = ""
+            # skip timeboards with no graphs in them
+            if not data["dash"]["graphs"]:
+                print("...Skipping '{}' as this timeboard has no widgets in it.".format(data["dash"]["title"].encode('utf8')))
+                continue
+            print("Pushing: {}".format(data["dash"]["title"].encode('utf8')))
+            if not arguments["--dry-run"]:
+                api.Timeboard.create(title=data["dash"]["title"],
+                                    description=data["dash"]["description"],
+                                    graphs=data["dash"]["graphs"],
+                                    read_only=data["dash"]["read_only"])
+            print("Pushed {} timeboards.".format(count))
+
+
+def push_monitors():
+    path = "none, running in dry mode."
+    count = 0
+
+    monitors = _files_to_json("monitors")
+    if not monitors:
+        exit("No monitors have been pulled yet. Consider pulling monitors first.")
+    for monitor in monitors:
+        with open(monitor) as f:
+            data = json.load(f)
+            count = count + 1
+            print("Pushing: {}".format(data["name"].encode('utf8')))
+            if not arguments["--dry-run"]:
+                api.Monitor.create(type=data['type'],
+                                    query=data['query'],
+                                    name=data['name'],
+                                    message=data['message'],
+                                    tags=data['tags'],
+                                    options=data['options'])
+    print("Pushed {} monitors.".format(count))
+    if not arguments["--dry-run"]:
+        print("NOTE! All monitors have been automatically muted to suppress monitors from triggering false/positive alert. Please make sure to remove th scheduled downtime in the GUI if this is not what you wanted.")
+        api.Monitor.mute_all()
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='0.1.1rc')
+
+    if arguments["--dry-run"]:
+        print("You are running in dry-mode. No actual pull/push will be done to the organizations.")
+
+    if arguments["pull"]:
+        _init_options("pull")
+        if arguments['<type>'] == 'screenboards':
+            pull_screenboards()
+        elif arguments['<type>'] == 'timeboards':
+            pull_timeboards()
+        elif arguments['<type>'] == 'monitors':
+            pull_monitors()
+    elif arguments["push"]:
+        _init_options("push")
+        if arguments['<type>'] == 'screenboards':
+            push_screenboards()
+        elif arguments['<type>'] == 'timeboards':
+            push_timeboards()
+        elif arguments['<type>'] == 'monitors':
+            push_monitors()

--- a/Dogmover/requirements.txt
+++ b/Dogmover/requirements.txt
@@ -1,0 +1,2 @@
+datadog>=0.3.0
+docopt

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When adding a new script/tool, be sure to do the following:
 We encourage creating a subfolder with a separate README that gives more details on the script/tool.
 
 ## Scripts & Tools
-These scripts and tools live in this repo, some scripts/tools have their own README in thheir subfolder with further explaintation and usage.
+These scripts and tools live in this repo, some scripts/tools have their own README in their subfolder with further explaintation and usage.
 
 | Name                                                                      | Language    | Function                                                                                                                                                                                                                                                                             |
 |---------------------------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -53,6 +53,7 @@ These scripts and tools live in this repo, some scripts/tools have their own REA
 | [get all groups in a monitor](./monitors/get_groups_in_monitor.py)               | Python      | queries for all groups in a monitor and outputs a list of them                                                                                                                                                                                                                              |
 | [create a csv file with a list of log in handles](./create_email_list.py)     | Python       | creates a CSV file in the same directory as the script containing a list of all user log in handles |
 | [Powershell script to call JSON REST endpoint, pass those key-value pairs to DogstatsD](./requester.ps1)     | Powershell       | A Powershell script which will call a given HTTP GET endpoint, and then submit the key-value pairs found in the resulting JSON body to DogsStatsD. Resource endpoint must be a non-nested JSON body ({"a":"1","b":"2"} -> custom metrics: a\|1, b\|2 |
+| [Dogmover](./Dogmover)							| Python	| Migrate screenboards, timeboards and monitors from one organization to another (supports migrations between US>EU instances.)
 ## Additional tools
 These are some additional tools and scripts written by Datadog.
 


### PR DESCRIPTION
This tool was originally built to help migrate customers screenboards, timeboards and monitors from our US instance to our EU instance. The tool also supports moving the data within the same instances (eg., EU to EU, or US to US and even EU to US.)