### PR TITLE
adding python2 shebang to Dogmover.py

### DIFF
--- a/Dogmover/dogmover.py
+++ b/Dogmover/dogmover.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 """Usage:
   dogmover.py pull (<type>) [--dry-run]
   dogmover.py push (<type>) [--dry-run]


### PR DESCRIPTION
Adding python2 shebang to Dogmover.py  as it's currently missing.