### PR TITLE
Adding parentheses to print functions

### DIFF
--- a/get_hostname_agentversion/get_host_agent_list.py
+++ b/get_hostname_agentversion/get_host_agent_list.py
@@ -8,13 +8,13 @@ url = "https://app.datadoghq.com/reports/v2/overview?api_key="+api_key+"&applica
 headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
 r = requests.get(url,headers=headers)
 
-print "status:", r.status_code
+print("status:", r.status_code)
 
 def get_host_agentVersion(data):
 	host_agent = agent_version(data)
 	with open ("host_agent_all.json",'w') as outfile:
 		json.dump(host_agent, outfile)
-	print "saved host_agent_all.json"
+	print("saved host_agent_all.json")
 
 def agent_version(data):
 	host_agent = []
@@ -28,12 +28,12 @@ def agent_version(data):
 			#	host_agent.append({"host_name": hosts["host_name"],"agent_version": hosts["meta"]["agent_version"]})
 			host_agent.append({"host_name": hosts["host_name"],"agent_version": hosts["meta"]["agent_version"]})
 	
-	print "extract host and agent version"
+	print("extract host and agent version")
 	return host_agent	
 
 if r.status_code == 200:
 	data = r.json()
 	with open ("JSON_API_permalink.json",'w') as outfile:
 		json.dump(r.json(), outfile)
-	print "saved JSON_API_permalink.json"
+	print("saved JSON_API_permalink.json")
 	get_host_agentVersion(data)


### PR DESCRIPTION
This PR adds parentheses to `print` functions to make script Python3-compatible  

#### Motivation: 
I received the following error when testing the script as it currently stands: 

```
  File "original_script.py", line 11
    print "status:", r.status_code
                  ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("status:", r.status_code)?
```

#### Investigation
Upon further investigation, it appears that the Python 2.x `print` statement was updated to the `print` function with the release of Python 3.x. As such, it requires parentheses when invoked. 

See Release Notes (https://docs.python.org/3/whatsnew/2.6.html#pep-3105-print-as-a-function ) 
> #### PEP 3105: `print` As a Function
>
>The `print` statement becomes the `print()` function in Python 3.0. Making `print()` a function makes it possible to replace the function by doing def print(...) or importing a new function from somewhere else.

#### Testing 
Upon adding the parentheses to the `print` functions, the script ran successfully, printing the expected statements:  

```
status: 200
saved JSON_API_permalink.json
extract host and agent version
saved host_agent_all.json
```