### PR TITLE
adding Packer, Terraform, AWS Secrets Manager example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ These scripts and tools live in this repo, some scripts/tools have their own REA
 | [PySNMP-MIB-Parser](./PySNMP-MIB-Parser)							| Python	| Converts a MIB file (in PySNMP format) to a yaml file that can be used by Datadog's [SNMP agent integration](https://docs.datadoghq.com/integrations/snmp/)  |
 | [aws_hosts_without_agent.py](./aws_hosts_without_agent.py)	| Python	| Gets a list of hostnames and IPs for AWS hosts not running the agent |
 | [DD Example](./dd-example)	| N/A	| Spins up a k8s cluster using Minikube with a simple app and database, showcasing the Datadog daemonset, has APM, Logs, and Metrics |
+| [Packer Image Build + Terraform Deploy with AWS Secrets Manager and Datadog Agent](./agent_bootstrapping/README.md) | N/A | A guide that helps you to build an AMI with updates + Datadog Agent preinstalled using Packer, and deploy to AWS using Terraform while storing your Datadog API key in AWS Secrets Manager and using an IAM Instance Profile to retrive it at deployment time. |
 
 ## Additional tools
 These are some additional tools and scripts written by Datadog.

--- a/agent_bootstrapping/.gitignore
+++ b/agent_bootstrapping/.gitignore
@@ -1,0 +1,11 @@
+**/*terraform.tfvars
+**/*.keys
+**/*.tfstate*
+**/\logfiles\/**
+.*
+!/.gitignore
+**/.delivery**
+**/.terraform
+**/*.tfvars
+**/\files\/**
+**/*.chef

--- a/agent_bootstrapping/README.md
+++ b/agent_bootstrapping/README.md
@@ -1,0 +1,9 @@
+# Datadog Agent Bootstrapping
+
+How to automate the Datadog Agent install into various build and deployment processes.
+
+* [Link](./packer_terraform_aws/README.md) | Build an AMI that is updated with the Datadog agent pre-installed using Packer, then deploy the same image using Terraform while enabling the agent by pulling the API key from AWS Secrets Manager.
+  * Tech Used:
+    * Packer
+    * Terraform
+    * AWS EC2, VPC, IAM and Secrets Manager

--- a/agent_bootstrapping/packer_terraform_aws/README.md
+++ b/agent_bootstrapping/packer_terraform_aws/README.md
@@ -1,0 +1,98 @@
+# Bootstrapping the Datadog Agent using Packer, Terraform and AWS Secrets Manager
+
+The Datadog Agent is pretty flexible in the fact that it allows you to perform an "install only" type of installation, that doesn't actually start the Agent, or send any data into Datadog for processing. This is useful when creating images that are pre-loaded with apps that your company needs. In this example, I'll show you how to;
+
+1. Create an AMI in AWS that has the latest updates and the latest Datadog Agent pre-installed by using Packer.
+1. Deploy and instance into AWS that uses your newly created AMI, and also takes advantage of AWS Secrets Manager to pull in your Datadog API key at deployment time automatically.
+
+## Why is this Useful?
+The really cool thing about this deployment method is that it allows the end-user to deploy instances to AWS without the need for managing secrets locally. Because we're using IAM Instance Profiles to configure instance-level access to AWS Secrets Manager, the instance just by being launched with the correct profile associated with it, will automatically have access to the secrets it needs (in this case the Datadog API key) to configure itself. 
+
+## Assumptions
+* To use the example Terraform code, you will need AWS access, and permissions to create an EC2 instance, VPC, Security Groups, IAM Roles and Profiles, an SSH keypair and AWS Secrets in Secrets Manager.
+* You have a local development environment (Mac, Windows, Linux), with the latest [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) (`v0.14.7` as of this writing) and [Packer](https://learn.hashicorp.com/tutorials/packer/getting-started-install) (`1.7.0` as of this writing) installed.
+* This code uses completely [AWS Free Tier](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc) eligable resources, however you should always double-check potential usage costs before deploying.
+* You have a [Datadog account](https://app.datadoghq.com/signup) and the ability to create/access an API key.
+* You have an understanding of Packer and Terraform, if you haven't used Packer or Terraform before, here are some excellent resources on what they are and how to use them.
+    * [Learn Terraform](https://learn.hashicorp.com/terraform)
+    * [Learn Packer](https://learn.hashicorp.com/packer)
+* You have an SSH keypair setup locally and have an understanding of how to SSH into a Linux server.
+* It's a good idea to have the AWS CLI tool installed locally for quick testing
+
+## Step 1 - Setup
+
+1. Locally, create a workspace directory to work from.
+1. Clone this repo into that directory.
+1. Copy just this directory and subdirectories/files (from root `./agent_bootstrapping/packer_terraform_aws`) into it's own directory outside of the repo, this is because you will be modifying the file contents.
+1. Change directory into the newly copied directory, all work will be done in here.
+1. First, edit the `./packer/ubuntu-xenial-16.04-amd64-server.pkr.hcl` file and change the `locals` variables:
+    ```
+    locals { 
+      ami_name_prefix = "ddog-ubuntu-xenial"
+      region = "us-east-2"
+      instance_type = "t2.micro"
+      ddog_url = "datadoghq.com" # Change to datadoghq.eu for EU
+      ddog_major_version = "7"
+      timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+      # Uncomment if you want to use a custom subnet
+      # subnet_id = "CHANGEME"
+    }
+    ```
+    The default values should be fine, however tweak them to  your needs. If you uncomment `subnet_id`, be sure to also uncomment the corresponding usage of it on `line 17`.
+1. Next, CD into the `./terraform` directory, and copy the `terraform.tfvars.example` to `terraform.tfvars`.
+1. All of these variables are customizable, but there are some that are required to be changed (marked with comment), specifically;
+    * *ami_name_prefix* - this should match the `ami_name_prefix` that was set in the Packer template in step 5. This is a regex, so the format is `name-prefix-*`, if you haven't changed the Packer template, then you don't need to change this.
+    * *iam, sg_info, instance_info* - the defaults are fine for a quick test, however you may want to customize these a bit more.
+    * *ssh_key* - this is important, make sure to at least set the `file` to the correct path of your Public SSH key.
+    * *ddog_api_key* - **Required** - youre Datadog API key, data won't show up without this.
+    * *owner_id* - **Required** - when pulling AMIs, Terraform will search based on the Owner ID (your AWS Account ID).
+    * *networking* - you can leave this as-is, or you can modify it to your liking, I typically use a separate VPC than default for most of my testing.
+    * *allowed_cidrs* - **Required** - this code will spin up an Admin Security Group that allows for connectivity into the instance from whatever IP subnet is defined, default is `0.0.0.0/0` for "Allow All", however I highly recommend setting this to your own public IP, for example in Google type "what is my ip", then enter what you see as `12.12.12.12/32`, replacing the `12`'s with your actual IP info.
+
+## Step 2 - Build an AMI
+The Packer template that is in this example does a few things:
+  * It runs updates on the Ubuntu system
+  * It installs the AWS CLI tool on the instance for easy retrieval of secrets from the instance
+  * It installs the Datadog agent in "Install Only" mode, and sets the API key to `PREINSTALL` as a value
+  * It deploys the newly created AMI to your account, ready for use
+
+1. First, be sure you have your AWS credentials configured properly on your local system, I recommend following this guide to make sure you have them set as either [environment variables](https://www.packer.io/docs/builders/amazon#environment-variables), or in a [shared credentials file](https://www.packer.io/docs/builders/amazon#shared-credentials-file). The good news is that you just need to do this once, as Terraform uses the same method for authentication.
+1. Next, CD into the `./packer` directory, and then run; 
+    ```
+    packer build ubuntu-xenial-16.04-amd64-server.pkr.hcl
+    ```
+1. This will build the AMI and deploy it to your account, a successful build will look something like this:
+    ```
+    ==> amazon-ebs.ubuntu-xenial: Waiting for the instance to stop...
+    ==> amazon-ebs.ubuntu-xenial: Creating AMI ddog-ubuntu-xenial-0063234234234c87e82a6 from instance i-0a150a29b32b4c589
+        amazon-ebs.ubuntu-xenial: AMI: ami-0063234234234c87e82a6
+    ==> amazon-ebs.ubuntu-xenial: Waiting for AMI to become ready...
+    ==> amazon-ebs.ubuntu-xenial: Terminating the source AWS instance...
+    ==> amazon-ebs.ubuntu-xenial: Cleaning up any extra volumes...
+    ==> amazon-ebs.ubuntu-xenial: No volumes to clean up, skipping
+    ==> amazon-ebs.ubuntu-xenial: Deleting temporary security group...
+    ==> amazon-ebs.ubuntu-xenial: Deleting temporary keypair...
+    Build 'amazon-ebs.ubuntu-xenial' finished after 8 minutes 17 seconds.
+
+    ==> Wait completed after 8 minutes 17 seconds
+
+    ==> Builds finished. The artifacts of successful builds are:
+    --> amazon-ebs.ubuntu-xenial: AMIs were created:
+    us-east-2: ami-0063234234234c87e82a6
+    ```
+1. That's really it, at this point you should see the AMI you've created in your account, you can run `aws ec2 describe-images --region us-east-2 --owners self --output json | grep ddog` to take a look at your images (replace `ddog` with whatever string identifies your AMI).
+
+## Step 3 - Deploy using Terraform
+The Terraform code included is meant to be fully self-contained, that means it creates an AWS Secret, SSH KeyPair, Instance, IAM Role, Instance Profile, and everything else needed to bootstrap an instance that is ready to read 1 specific secret out of the box. This example doesn't take into account many best practices from Hashicorp due to the fact that it's just meant to show off the process. **So if you use any of this code, please be sure to fully understand what it is doing, and follow [Terraform Recommended Practices](https://www.terraform.io/docs/cloud/guides/recommended-practices/index.html) when deploying.**
+
+1. CD into the `./terraform` directory.
+1. Run `terraform init` to initialize the AWS and Template plugins.
+1. Run `terraform plan` to see what is about to be deployed, be sure to fix any errors you see in syntax.
+1. After you have verified everything, run `terraform apply`, you will then be prompted to answer `yes` to continue, do so if everything looks ok.
+1. Unless you've skipped ahead, you'll notice that everything deployed _except for_ and actual instance, this is because by default, this code has the instance `count` set to `0`, so go into the `ubuntu-xenial.tf` file and change `count = 0` to `count = 1` on `line 27`.
+1. Go through the `terraform plan`, then `terraform apply` process again.
+1. Once done, you should now have an Ubuntu instance in AWS that is based on the AMI that you built previously in Step 2.
+1. You can now ssh into the instance to verify that it's up and running, and run `sudo datadog-agent status` to verify the agent is working properly. After a few minutes, you will start to see data for the instance show up in Datadog.
+
+
+Now if you use that AMI combined with the proper IAM Instance Profile for all future deployments, your instances will automatically have Datadog Agent installed and reporting.

--- a/agent_bootstrapping/packer_terraform_aws/packer/ubuntu-xenial-16.04-amd64-server.pkr.hcl
+++ b/agent_bootstrapping/packer_terraform_aws/packer/ubuntu-xenial-16.04-amd64-server.pkr.hcl
@@ -1,0 +1,42 @@
+locals { 
+  ami_name_prefix = "ddog-ubuntu-xenial"
+  region = "us-east-2"
+  instance_type = "t2.micro"
+  ddog_url = "datadoghq.com" # Change to datadoghq.eu for EU
+  ddog_major_version = "7"
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  # Uncomment if you want to use a custom subnet
+  # subnet_id = "CHANGEME"
+}
+
+source "amazon-ebs" "ubuntu-xenial" {
+  ami_name      = "${local.ami_name_prefix}-${local.timestamp}"
+  instance_type = local.instance_type
+  region        = local.region
+  # Uncomment the subnet_id if you are using a custom subnet
+  # subnet_id     = local.subnet_id
+  associate_public_ip_address = true
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+  ssh_username = "ubuntu"
+}
+
+build {
+  sources = ["source.amazon-ebs.ubuntu-xenial"]
+
+  provisioner "shell" {
+      inline = [
+          "sudo apt-get update -y",
+          "sudo apt-get install awscli -y",
+          "sudo DD_AGENT_MAJOR_VERSION=${local.ddog_major_version} DD_API_KEY=PREINSTALL DD_INSTALL_ONLY=true DD_SITE=\"${local.ddog_url}\" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)\""
+        ]
+  }
+}
+

--- a/agent_bootstrapping/packer_terraform_aws/terraform/iam.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/iam.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_role" "ddog_api_key" {
+  name = var.iam["iam_role_name"]
+
+  assume_role_policy = <<EOF
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+         "Effect":"Allow",
+         "Principal":{
+            "Service":"ec2.amazonaws.com"
+         },
+         "Action":"sts:AssumeRole",
+         "Sid": ""
+      }
+   ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "ddog_api_key" {
+  name = var.iam["iam_instance_profile_name"]
+  role = aws_iam_role.ddog_api_key.name
+}
+
+resource "aws_iam_policy" "ddog_api_key" {
+  name = var.iam["iam_policy_name"]
+  path = "/"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "${aws_secretsmanager_secret.ddog_api_key.id}"
+        }
+    ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy_attachment" "ddog_attach" {
+  role       = aws_iam_role.ddog_api_key.name
+  policy_arn = aws_iam_policy.ddog_api_key.arn
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/network.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/network.tf
@@ -1,0 +1,45 @@
+# Network Setup
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "main_vpc" {
+  cidr_block = var.networking["main_vpc_cidr_block"]
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = var.networking["main_vpc_name"]
+  }
+}
+
+resource "aws_subnet" "main_subnet_00" {
+  vpc_id            = aws_vpc.main_vpc.id
+  cidr_block        = var.networking["main_subnet_00"]
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = var.networking["main_subnet_00_name"]
+  }
+}
+
+resource "aws_internet_gateway" "main_gw" {
+  vpc_id = aws_vpc.main_vpc.id
+  tags = {
+    Name = var.networking["main_igw_name"]
+  }
+}
+
+# Route tables
+resource "aws_route_table" "main_subnet_00" {
+  vpc_id = aws_vpc.main_vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main_gw.id
+  }
+  tags = {
+    Name = var.networking["main_subnet_00_route_table_name"]
+  }
+}
+
+resource "aws_route_table_association" "main_subnet_00" {
+  subnet_id      = aws_subnet.main_subnet_00.id
+  route_table_id = aws_route_table.main_subnet_00.id
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/provider.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/provider.tf
@@ -1,0 +1,4 @@
+# Provider AWS
+provider "aws" {
+  region = var.aws_region
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/secrets.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/secrets.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "ddog_api_key" {
+  name = "ddog_api_key"
+}
+
+resource "aws_secretsmanager_secret_version" "ddog_api_key" {
+  secret_id     = aws_secretsmanager_secret.ddog_api_key.id
+  secret_string = var.ddog_api_key
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/security_group.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/security_group.tf
@@ -1,0 +1,108 @@
+# Admin SG
+resource "aws_security_group" "admin" {
+  name        = "admin"
+  description = "Allow inbound SSH traffic to Admin VPC from allowed IPs"
+  vpc_id      = aws_vpc.main_vpc.id
+  tags = {
+    Name = "BrightOps Main Admin Security Group"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_ssh_admin_allowed_cidrs" {
+    type        = "ingress"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+    security_group_id = aws_security_group.admin.id
+}
+resource "aws_security_group_rule" "ingress_https_admin_allowed_cidrs" {
+    type        = "ingress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+    security_group_id = aws_security_group.admin.id
+}
+
+resource "aws_security_group_rule" "ingress_winrm_ssl_admin_allowed_cidrs" {
+    type        = "ingress"
+    from_port   = 5986
+    to_port     = 5986
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+    security_group_id = aws_security_group.admin.id
+}
+
+resource "aws_security_group_rule" "ingress_rdp_admin_allowed_cidrs" {
+    type        = "ingress"
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+    security_group_id = aws_security_group.admin.id
+}
+
+resource "aws_security_group_rule" "ingress_winrm_admin_allowed_cidrs" {
+    type        = "ingress"
+    from_port   = 5985
+    to_port     = 5985
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+    security_group_id = aws_security_group.admin.id
+}
+
+resource "aws_security_group_rule" "egress_admin" {
+    type            = "egress"
+    from_port       = 0
+    to_port         = 0
+    protocol = "-1"
+    security_group_id = aws_security_group.admin.id
+    source_security_group_id = aws_security_group.internal.id
+}
+
+resource "aws_security_group_rule" "egress_admin_all" {
+    type            = "egress"
+    from_port       = 0
+    to_port         = 0
+    protocol = "-1"
+    security_group_id = aws_security_group.admin.id
+    cidr_blocks = ["0.0.0.0/0"]
+}
+
+# Internal SG
+resource "aws_security_group" "internal" {
+  name        = "internal"
+  description = "Allow all inbound traffic to the Internal VPC from Admin SG and SELF SG"
+  vpc_id      = aws_vpc.main_vpc.id
+  tags = {
+    Name = "BrightOps Main Internal Security Group"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_internal_from_admin" {
+    type            = "ingress"
+    from_port       = 0
+    to_port         = 0
+    protocol = "-1"
+    security_group_id = aws_security_group.internal.id
+    source_security_group_id = aws_security_group.admin.id
+}
+
+resource "aws_security_group_rule" "ingress_internal" {
+    type            = "ingress"
+    from_port       = 0
+    to_port         = 0
+    protocol = "-1"
+    security_group_id = aws_security_group.internal.id
+    source_security_group_id = aws_security_group.internal.id
+}
+
+resource "aws_security_group_rule" "egress_internal" {
+    type            = "egress"
+    from_port       = 0
+    to_port         = 0
+    protocol = "-1"
+    security_group_id = aws_security_group.internal.id
+    cidr_blocks = ["0.0.0.0/0"]
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/ssh.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/ssh.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "ddog_ssh_key" {
+  key_name   = var.ssh_key["name"]
+  public_key = file(var.ssh_key["file"])
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/terraform.tfvars.example
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/terraform.tfvars.example
@@ -1,0 +1,38 @@
+aws_region = "us-east-2"
+iam = {
+  iam_role_name = "ddog_role"
+  iam_instance_profile_name = "ddog_instance_profile"
+  iam_policy_name = "ddog_policy"
+}
+sg_info = {
+  admin_sg_name = "My Admin SG"
+  internal_sg_name = "My Internal SG"
+}
+instance_info = {
+  ubuntu_xenial_name = "My Ubuntu Xenial Demo Instance"
+  ubuntu_xenial_instance_type = "t2.micro"
+  ubuntu_xenial_ami_string = "ddog-ubuntu-xenial-*"
+}
+ssh_key = {
+  name = "ddog_pub_key"
+  file = "/Users/my.user/.ssh/id_rsa.pub"
+}
+ddog_api_key = "mydatadogapikey"
+owner_id = "myawsownerid"
+networking = {
+  # VPC and IGW Details
+  main_vpc_cidr_block = "10.12.23.0/24" # Small subnet for testing, feel free to change
+  main_vpc_name = "My Org Main VPC"
+  main_igw_name = "My Org Internet Gateway for Main VPC"
+  # Subnet Details
+  main_subnet_00 = "10.12.23.0/27" # 30 useable IPs
+  main_subnet_00_name = "My Org Main Subnet 00"
+  main_subnet_00_route_table_name = "My Org Route Table for Main Subnet 00"
+  main_subnet_01 = "10.12.23.32/28" # 14 useable IPs
+  main_subnet_01_name = "My Org Main Subnet 01"
+  main_subnet_01_route_table_name = "My Org Route Table for Main Subnet 01"
+  main_subnet_02 = "10.12.23.48/28" # 14 useable IPs
+  main_subnet_02_name = "My Org Main Subnet 02"
+  main_subnet_02_route_table_name = "My Org Route Table for Main Subnet 02"
+}
+allowed_cidrs  = ["YOUR.PUBLIC.I.P/32"] # Allowed CIDRs for Admin SG, should be limited

--- a/agent_bootstrapping/packer_terraform_aws/terraform/ubuntu-xenial.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/ubuntu-xenial.tf
@@ -1,0 +1,39 @@
+# EC2 Setup
+data "aws_ami" "ubuntu_xenial" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = [var.instance_info["ubuntu_xenial_ami_string"]]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = [var.owner_id]
+}
+
+data "template_file" "ubuntu_xenial_user_data" {
+  template = file("./user_data/enable_ddog_agent_ubuntu_xenial.sh.tpl")
+
+  vars = {
+    secret_id = aws_secretsmanager_secret.ddog_api_key.name
+  }
+}
+
+resource "aws_instance" "ddog_instance_ubuntu_xenial" {
+  count = 0
+  ami = data.aws_ami.ubuntu_xenial.id
+  instance_type = var.instance_info["ubuntu_xenial_instance_type"]
+  key_name = var.ssh_key["name"]
+  associate_public_ip_address = true
+  subnet_id = aws_subnet.main_subnet_00.id
+  vpc_security_group_ids = [aws_security_group.admin.id, aws_security_group.internal.id]
+  iam_instance_profile = aws_iam_instance_profile.ddog_api_key.id
+  user_data = data.template_file.ubuntu_xenial_user_data.rendered
+  tags = {
+    Name = var.instance_info["ubuntu_xenial_name"]
+  }
+}

--- a/agent_bootstrapping/packer_terraform_aws/terraform/vars.tf
+++ b/agent_bootstrapping/packer_terraform_aws/terraform/vars.tf
@@ -1,0 +1,95 @@
+variable "networking" {
+  type = map
+  description = "Network info for the VPC and it's subnets"
+  default = {
+    # VPC and IGW Details
+    main_vpc_cidr_block = "10.12.23.0/24" # Small subnet for testing, feel free to change
+    main_vpc_name = "Datadog Main VPC"
+    main_igw_name = "Datadog Internet Gateway for Main VPC"
+    # Subnet Details
+    main_subnet_00 = "10.12.23.0/27" # 30 useable IPs
+    main_subnet_00_name = "Datadog Main Subnet 00"
+    main_subnet_00_route_table_name = "Datadog Route Table for Main Subnet 00"
+    main_subnet_01 = "10.12.23.32/28" # 14 useable IPs
+    main_subnet_01_name = "Datadog Main Subnet 01"
+    main_subnet_01_route_table_name = "Datadog Route Table for Main Subnet 01"
+    main_subnet_02 = "10.12.23.48/28" # 14 useable IPs
+    main_subnet_02_name = "Datadog Main Subnet 02"
+    main_subnet_02_route_table_name = "Datadog Route Table for Main Subnet 02"
+  }
+}
+
+variable "allowed_cidrs" {
+  type = list(string)
+  description = "Allowed CIDRs for the Admin Security Group"
+  default = ["0.0.0.0/0"]
+}
+
+variable "aws_region" {
+  type = string
+  description = "AWS Default Region"
+  default = "CHANGEME"
+}
+
+variable "owner_id" {
+  type = string
+  description = "Account Owner ID for looking up AMIs"
+  default = "CHANGEME"
+  sensitive = true
+}
+
+variable "ddog_api_key" {
+  type = string
+  description = "Datadog API Key"
+  default = "CHANGEME"
+  sensitive = true
+}
+
+variable "iam" {
+  type = map
+  description = "IAM Policy Info"
+  default = {
+    iam_role_name = ""
+    iam_instance_profile_name = ""
+    iam_policy_name = ""
+  }
+}
+
+variable "sg_info" {
+  type = map
+  description = "Security Group Info"
+  default = {
+    admin_sg_name = "Admin SG"
+    internal_sg_name = "Internal SG"
+  }
+}
+
+variable "admin_sg_name" {
+    type = string
+    description = "Friendly name for the Admin Security Group"
+    default = "Admin SG"
+}
+
+variable "internal_sg_name" {
+    type = string
+    description = "Friendly name for the Internal Security Group"
+    default = "Internal SG"
+}
+
+variable "instance_info" {
+    type = map
+    description = "Instance Info for each O/S"
+    default = {
+      ubuntu_xenial_name = "Ubuntu Xenial Datadog Instance"
+      ubuntu_xenial_instance_type = "t2.micro"
+      ubuntu_xenial_ami_string    = "ddog-ubuntu-xenial-*"
+    }
+}
+variable "ssh_key" {
+  type = map
+  description = "EC2 instance SSH key settings"
+  default = {
+    name = "My Super Awesome SSH key"
+    file = "/change/path/to/publick-key"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Daniel Bright <daniel.bright@datadoghq.com>

This guide + example code will walk an end-user through the process of creating an AMI in AWS that is updated and has the Datadog Agent pre-installed. It will then allow them to deploy the AMI using Terraform and AWS Secrets Manager to update the Agent config and start it during actual deployment.