### PR TITLE
dogmover: run with python3

### DIFF
--- a/Dogmover/Dockerfile
+++ b/Dogmover/Dockerfile
@@ -1,12 +1,8 @@
-#FROM python:2-slim
 FROM python:3-slim
 
 WORKDIR /dogmover
-COPY . /dogmover
+COPY requirements.txt requirements.txt
 
 RUN pip install -r requirements.txt --upgrade
 
-RUN chmod +x dogmover.py
-
 ENTRYPOINT ["./dogmover.py"]
-

--- a/Dogmover/dogmover.py
+++ b/Dogmover/dogmover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env
+#!/usr/bin/env python3
 """Usage:
   dogmover.py pull (<type>) [--tag tag]... [--dry-run] [-h]
   dogmover.py push (<type>) [--dry-run] [-h]


### PR DESCRIPTION
Run `dogmover.py` with the environment specified python3 binary. 

With `#!/usr/bin/env`, executing `./dogmover.py`  never produces any output. Running `./dogmover.py -h` does not produce any output.

With `#!/usr/bin/env python3`, executing `./dogmover.py` runs as expected.

Since the docker container is executed by mounting the current directory and `dogmover.py` is already an executable file in this repository, copy the requirements file and pip install. 
