### PR TITLE
added invalid_keys to push_synthetics_*_tests

### DIFF
--- a/Dogmover/dogmover.py
+++ b/Dogmover/dogmover.py
@@ -373,7 +373,7 @@ def push_synthetics_api_tests(options):
          with open(synthetic) as f:
             data = json.load(f)
             count = count + 1
-            invalid_keys = ["public_id", "monitor_id"]
+            invalid_keys = ["public_id", "monitor_id", "modified_at", "creator", "created_at"]
             list(map(data.pop, invalid_keys))
             print("Pushing {}".format(data["name"].encode('utf8')))
             if not arguments["--dry-run"]:
@@ -390,7 +390,7 @@ def push_synthetics_browser_tests(options):
          with open(synthetic) as f:
             data = json.load(f)
             count = count + 1
-            invalid_keys = ["public_id", "monitor_id"]
+            invalid_keys = ["public_id", "monitor_id", "modified_at", "creator", "created_at"]
             list(map(data.pop, invalid_keys))
             print("Pushing {}".format(data["name"].encode('utf8')))
             if not arguments["--dry-run"]:


### PR DESCRIPTION
Added "modified_at", "creator", "created_at" as invalid_keys for both browser and api synthetic pushes. Without these values the push would appear to be successful with no errors returned on CLI, but in reality was generating a 400 status code.