### PR TITLE
Python script to get all unused tags of the metric

### DIFF
--- a/get_all_unused_tags/Readme.md
+++ b/get_all_unused_tags/Readme.md
@@ -1,0 +1,10 @@
+This script will list all the tags of the metrics which are not in use in the datadog.
+It is useful in cases where you want to list the metrics and their tags. This script is using 2 API's https://docs.datadoghq.com/api/latest/metrics/?code-lang=python#list-tags-by-metric-name and https://docs.datadoghq.com/api/latest/metrics/?code-lang=python#list-active-tags-and-aggregations.
+The 1st API will fetch all the tags of the metric and other one will just list all active tags and attributes.
+After filtering and converting both into the python list. It will perform subtraction of active tags from all tags list, which will show the unused tags.
+
+I've tested this script on Ubuntu 22.04.3 LTS, and it should work with most flavors of Linux running a kernel version of 2.6 or higher. 
+
+The script depends on the datadog Python3 and its package, both of which can be installed with the pip install command.
+
+To use the script, enter your API and app keys in the options dictionary. Then, specify the path to the file which will have list of metrics. The script will excecute for all the metrics mentioned in that file.

--- a/get_all_unused_tags/get_unused_tags_of_metrics.py
+++ b/get_all_unused_tags/get_unused_tags_of_metrics.py
@@ -1,0 +1,43 @@
+"""
+List tags by metric name returns "Success" response
+
+"""
+import json
+from os import environ
+from datadog_api_client import ApiClient, Configuration
+from datadog_api_client.v2.api.metrics_api import MetricsApi
+# using readlines()
+file1 = open('path/to/file/having/list/of/metrics', 'r')
+Lines = file1.readlines()
+ 
+count = 0
+# Strips the newline character
+for line in Lines:
+    count += 1
+    metric = line.strip()
+    configuration = Configuration()
+    configuration.api_key["apiKeyAuth"] = ""
+    configuration.api_key["appKeyAuth"] = ""
+    #get list of all tags of the metric
+    with ApiClient(configuration) as api_client:
+        api_instance = MetricsApi(api_client)
+        response = api_instance.list_tags_by_metric_name(
+            metric_name = metric,
+        )
+        #split to fetch just tag name and not value
+        tags = [tag.split(":")[0] for tag in response['data']['attributes']['tags']]
+        list_alltags = []
+        for tag in tags:
+           list_alltags.append(tag)
+        myset_alltags = set(list_alltags)
+    #get list of active tags of the same metric    
+    with ApiClient(configuration) as api_client:
+        api_instance = MetricsApi(api_client)
+        response = api_instance.list_active_metric_configurations(
+        metric_name= metric,
+        )
+        active_tags = response['data']['attributes']['active_tags']
+        myset_active = set(active_tags)
+        #get the list of unused tags by subtracting active tags from all tags list 
+        missing = list(sorted(myset_alltags - myset_active))
+        print("metric:", metric,"All tags: ",myset_alltags,"Active tags: ",myset_active,"Unused tags: ",missing)

--- a/get_all_unused_tags/metrics.txt
+++ b/get_all_unused_tags/metrics.txt
@@ -1,0 +1,10 @@
+metric1
+metric2
+metric3
+metric4
+metric5
+metric6
+metric7
+metric8
+metric9
+metric10


### PR DESCRIPTION
This script will list all the tags of the metrics which are not in use in the datadog.